### PR TITLE
Fix incorrect conditional check for podman image exists in image pull script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -85,24 +85,19 @@ pull_containers() {
 
     mapfile -t images < <(sed -n 's/^Image=//p' "$quadlet_dir/spring_$service/"*.container)
 
-    for image in ${images[@]}; do
-
-        podman image exists $image
-
-        if [ -z $? ]; then
+    for image in "${images[@]}"; do
+        if ! podman image exists "$image"; then
             echo -e "    Fetching image: ${GREEN}${BOLD}$image${NOBOLD}${NC}"
 
-            result=$(podman pull $image 2>&1)
-
+            result=$(podman pull "$image" 2>&1)
             if [ $? -ne 0 ]; then
                 echo -e "  ${RED}${BOLD}Image pull failed!${NOBOLD}${NC}. Error:"
                 echo -e "${YELLOW}$result${NC}"
                 echo -e "  ${RED}Exiting${NC}"
-                exit 1;
+                exit 1
             fi
         fi
     done
-
 }
 
 create_secret() {


### PR DESCRIPTION
This pull request fixes a logic error in the image pull script where the conditional check for podman image exists was incorrectly implemented as:

`if [ -z $? ]; then`

This is problematic because:
- $? returns an exit code (e.g., 0 or 1), not a string.
- The -z operator checks for zero-length strings, which is not appropriate here.
- Due to this, the condition always evaluates incorrectly and may skip pulling missing images.

**Fix:**

Replaced the faulty conditional with a direct check using logical negation:

```
if ! podman image exists "$image"; then
    ...
fi
```

This ensures the script correctly identifies when an image is not present and proceeds to pull it.