### PR TITLE
Add SUID bit check and auto-fix for newuidmap and newgidmap in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -202,6 +202,17 @@ if ! command -v "podman" &> /dev/null; then
     exit 1
 fi
 
+if [ ! -u /usr/bin/newuidmap ] || [ ! -u /usr/bin/newgidmap ]; then
+    echo -e "${YELLOW}SUID bit is not set on /usr/bin/newuidmap or /usr/bin/newgidmap.${NC}"
+    if ask_yes_no "Would you like to fix this now (requires sudo)?" "y"; then
+        sudo chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap
+        echo -e "${GREEN}SUID bits applied.${NC}"
+    else
+        echo -e "${RED}Rootless containers may not work correctly without this. Exiting.${NC}"
+        exit 1
+    fi
+fi
+
 ###
 ### SPRING
 ###


### PR DESCRIPTION
This PR enhances the `setup.sh` script by checking for the required SUID bits on `/usr/bin/newuidmap` and `/usr/bin/newgidmap`. These permissions are necessary for rootless Podman containers to function properly when using user namespaces.

Rootless Podman requires the `newuidmap` and `newgidmap` binaries to have the SetUID bit enabled so that unprivileged users can map UID/GID ranges during container startup.

Without this, SPRING services relying on rootless containers may fail silently or exhibit permission-related issues.

Changelog:

- Checks whether both binaries have the correct SUID bit using `[ -u FILE ]`.
- If not set:
    - Prompts the user to fix the issue with `sudo chmod u+s`.
    - Exits if the user declines, ensuring misconfigured environments don’t proceed.